### PR TITLE
Put the source path into quotes to fix issue on path with spaces

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,59 +47,59 @@ install() {
 
   echo "Installing '${THEME_DIR}'..."
 
-  mkdir -p                                                                                 ${THEME_DIR}
-  cp -r ${SRC_DIR}/{COPYING,AUTHORS}                                                       ${THEME_DIR}
-  cp -r ${SRC_DIR}/src/index.theme                                                         ${THEME_DIR}
+  mkdir -p                                                                                   ${THEME_DIR}
+  cp -r "${SRC_DIR}"/{COPYING,AUTHORS}                                                       ${THEME_DIR}
+  cp -r "${SRC_DIR}"/src/index.theme                                                         ${THEME_DIR}
 
   cd ${THEME_DIR}
   sed -i "s/${name}/${name}${theme}${color}/g" index.theme
 
   if [[ ${color} == '' ]]; then
-    mkdir -p                                                                               ${THEME_DIR}/status
-    cp -r ${SRC_DIR}/src/{actions,animations,apps,categories,devices,emblems,mimes,places} ${THEME_DIR}
-    cp -r ${SRC_DIR}/src/status/{16,22,24,32,symbolic}                                     ${THEME_DIR}/status
+    mkdir -p                                                                                 ${THEME_DIR}/status
+    cp -r "${SRC_DIR}"/src/{actions,animations,apps,categories,devices,emblems,mimes,places} ${THEME_DIR}
+    cp -r "${SRC_DIR}"/src/status/{16,22,24,32,symbolic}                                     ${THEME_DIR}/status
 
     if [[ ${black:-} == 'true' ]]; then
       sed -i "s/#ffffff/#363636/g" "${THEME_DIR}"/status/{16,22,24}/*
     fi
 
     if [[ ${bold:-} == 'true' ]]; then
-      cp -r ${SRC_DIR}/bold/*                                                              ${THEME_DIR}
+      cp -r "${SRC_DIR}"/bold/*                                                              ${THEME_DIR}
     fi
 
-    cp -r ${SRC_DIR}/links/{actions,apps,categories,devices,emblems,mimes,places,status}   ${THEME_DIR}
+    cp -r "${SRC_DIR}"/links/{actions,apps,categories,devices,emblems,mimes,places,status}   ${THEME_DIR}
 
     if [[ $DESKTOP_SESSION == '/usr/share/xsessions/budgie-desktop' ]]; then
-      cp -r ${SRC_DIR}/src/status/symbolic-budgie/*.svg                                    ${THEME_DIR}/status/symbolic
+      cp -r "${SRC_DIR}"/src/status/symbolic-budgie/*.svg                                    ${THEME_DIR}/status/symbolic
     fi
 
     if [[ ${alternative:-} == 'true' ]]; then
-      cp -r ${SRC_DIR}/alternative/apps/*.svg                                              ${THEME_DIR}/apps/scalable
+      cp -r "${SRC_DIR}"/alternative/apps/*.svg                                              ${THEME_DIR}/apps/scalable
     fi
 
     if [[ ${theme} != '' ]]; then
-      cp -r ${SRC_DIR}/colors/color${theme}/*.svg                                          ${THEME_DIR}/places/scalable
+      cp -r "${SRC_DIR}"/colors/color${theme}/*.svg                                          ${THEME_DIR}/places/scalable
     fi
   fi
 
   if [[ ${color} == '-dark' ]]; then
-    mkdir -p                                                                               ${THEME_DIR}/{apps,categories,emblems,devices,mimes,places,status}
+    mkdir -p                                                                                 ${THEME_DIR}/{apps,categories,emblems,devices,mimes,places,status}
 
-    cp -r ${SRC_DIR}/src/actions                                                           ${THEME_DIR}
-    cp -r ${SRC_DIR}/src/apps/symbolic                                                     ${THEME_DIR}/apps
-    cp -r ${SRC_DIR}/src/categories/symbolic                                               ${THEME_DIR}/categories
-    cp -r ${SRC_DIR}/src/emblems/symbolic                                                  ${THEME_DIR}/emblems
-    cp -r ${SRC_DIR}/src/mimes/symbolic                                                    ${THEME_DIR}/mimes
-    cp -r ${SRC_DIR}/src/devices/{16,22,24,symbolic}                                       ${THEME_DIR}/devices
-    cp -r ${SRC_DIR}/src/places/{16,22,24,symbolic}                                        ${THEME_DIR}/places
-    cp -r ${SRC_DIR}/src/status/{16,22,24,symbolic}                                        ${THEME_DIR}/status
+    cp -r "${SRC_DIR}"/src/actions                                                           ${THEME_DIR}
+    cp -r "${SRC_DIR}"/src/apps/symbolic                                                     ${THEME_DIR}/apps
+    cp -r "${SRC_DIR}"/src/categories/symbolic                                               ${THEME_DIR}/categories
+    cp -r "${SRC_DIR}"/src/emblems/symbolic                                                  ${THEME_DIR}/emblems
+    cp -r "${SRC_DIR}"/src/mimes/symbolic                                                    ${THEME_DIR}/mimes
+    cp -r "${SRC_DIR}"/src/devices/{16,22,24,symbolic}                                       ${THEME_DIR}/devices
+    cp -r "${SRC_DIR}"/src/places/{16,22,24,symbolic}                                        ${THEME_DIR}/places
+    cp -r "${SRC_DIR}"/src/status/{16,22,24,symbolic}                                        ${THEME_DIR}/status
 
     if [[ ${bold:-} == 'true' ]]; then
-      cp -r ${SRC_DIR}/bold/*                                                              ${THEME_DIR}
+      cp -r "${SRC_DIR}"/bold/*                                                              ${THEME_DIR}
     fi
 
     if [[ $DESKTOP_SESSION == '/usr/share/xsessions/budgie-desktop' ]]; then
-      cp -r ${SRC_DIR}/src/status/symbolic-budgie/*.svg                                ${THEME_DIR}/status/symbolic
+      cp -r "${SRC_DIR}"/src/status/symbolic-budgie/*.svg                                    ${THEME_DIR}/status/symbolic
     fi
 
     # Change icon color for dark theme
@@ -107,13 +107,13 @@ install() {
     sed -i "s/#363636/#dedede/g" "${THEME_DIR}"/actions/32/*
     sed -i "s/#363636/#dedede/g" "${THEME_DIR}"/{actions,apps,categories,emblems,devices,mimes,places,status}/symbolic/*
 
-    cp -r ${SRC_DIR}/links/actions/{16,22,24,32,symbolic}                                  ${THEME_DIR}/actions
-    cp -r ${SRC_DIR}/links/devices/{16,22,24,symbolic}                                     ${THEME_DIR}/devices
-    cp -r ${SRC_DIR}/links/places/{16,22,24,symbolic}                                      ${THEME_DIR}/places
-    cp -r ${SRC_DIR}/links/status/{16,22,24,symbolic}                                      ${THEME_DIR}/status
-    cp -r ${SRC_DIR}/links/apps/symbolic                                                   ${THEME_DIR}/apps
-    cp -r ${SRC_DIR}/links/categories/symbolic                                             ${THEME_DIR}/categories
-    cp -r ${SRC_DIR}/links/mimes/symbolic                                                  ${THEME_DIR}/mimes
+    cp -r "${SRC_DIR}"/links/actions/{16,22,24,32,symbolic}                                  ${THEME_DIR}/actions
+    cp -r "${SRC_DIR}"/links/devices/{16,22,24,symbolic}                                     ${THEME_DIR}/devices
+    cp -r "${SRC_DIR}"/links/places/{16,22,24,symbolic}                                      ${THEME_DIR}/places
+    cp -r "${SRC_DIR}"/links/status/{16,22,24,symbolic}                                      ${THEME_DIR}/status
+    cp -r "${SRC_DIR}"/links/apps/symbolic                                                   ${THEME_DIR}/apps
+    cp -r "${SRC_DIR}"/links/categories/symbolic                                             ${THEME_DIR}/categories
+    cp -r "${SRC_DIR}"/links/mimes/symbolic                                                  ${THEME_DIR}/mimes
 
     cd ${dest}
     ln -s ../${name}${theme}/animations ${name}${theme}-dark/animations


### PR DESCRIPTION
Title is self explanatory. I was having issue when trying to install the theme from my cloned repo that has a spaces in its absolute path (something like `/home/ian/Projects/My Themes/Colloid-gtk-theme`). The quotes should fix the issue