### PR TITLE
Add `rust-rover.svg` link for compatibility

### DIFF
--- a/links/apps/scalable/rust-rover.svg
+++ b/links/apps/scalable/rust-rover.svg
@@ -1,0 +1,1 @@
+rustrover.svg


### PR DESCRIPTION
As the title says, I've added a `rust-rover.svg` link for compatibility.