### PR TITLE
Update the zen browser flatpak id

### DIFF
--- a/links/apps/scalable/app.zen_browser.zen.svg
+++ b/links/apps/scalable/app.zen_browser.zen.svg
@@ -1,0 +1,1 @@
+zen_browser.svg


### PR DESCRIPTION
The new flatpak ID is [app.zen_browser.zen](https://flathub.org/apps/app.zen_browser.zen)