### PR TITLE
Apply KDE Plasma logo to WhiteSur-dark theme variant

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -143,6 +143,10 @@ install() {
       cp -r "${SRC_DIR}"/alternative/places/scalable/*.svg                                   "${THEME_DIR}"/places/scalable
     fi
 
+    if [[ ${plasma:-} == 'true' ]]; then
+      cp -r "${SRC_DIR}"/plasma/*                                                            "${THEME_DIR}"
+    fi
+
     if [[ ${theme} != '' ]]; then
       cp -r "${SRC_DIR}"/colors/color${theme}/*.svg                                          "${THEME_DIR}"/places/scalable
     fi


### PR DESCRIPTION
## Summary
- Apply the `-p` / `--kde-plasma` option during dark theme installation, not just the base theme
- Fixes `WhiteSur-dark` keeping the Apple start-here logo while `WhiteSur` and `WhiteSur-light` correctly show the KDE Plasma logo

## Test plan
- [x] Run `./install.sh -p` and verify `places/16/start-here.svg` in all three installed themes matches `plasma/places/16/start-here.svg`
- [x] Run `./install.sh -a -p` and confirm both alternative icons and the Plasma logo appear in `WhiteSur-dark`
- [x] Confirm `WhiteSur` and `WhiteSur-light` behavior is unchanged


Made with [Cursor](https://cursor.com)